### PR TITLE
選択したメニューにアンダーバーを付与

### DIFF
--- a/src/components/CoomonNavbar.vue
+++ b/src/components/CoomonNavbar.vue
@@ -18,5 +18,7 @@ export default {
 </script>
 
 <style>
-
+.nav-item > .router-link-exact-active {
+  border-bottom: solid;
+}
 </style>


### PR DESCRIPTION
## 概要
選択したメニューにアンダーバーを付与するように変更

## キャプチャ
![2019-10-12 22 54 27](https://user-images.githubusercontent.com/30320735/66702545-ce39d880-ed43-11e9-8fe0-68d78ea9d7a0.gif)

## ナレッジ

### BootstrapVue のコンポーネント `<b-nav-item>`

`<b-nav-item>` は `<router-link>` のレンダリングをサポートしている。
https://bootstrap-vue.js.org/docs/reference/router-links/

### `<router-link>` のプロパティ `exact-active-class`

`<router-link>` がアクティブになっているときに適用される CSS クラスを設定するプロパティ。
デフォルト値は `router-link-exact-active` 。

つまり、デフォルトではアクティブな `<router-link>` に `router-link-exact-active` という class が追加される設定になっているということ。
（今回はこのクラスをセレクタに使うことで、アクティブなメニューを装飾した）
https://router.vuejs.org/ja/api/#exact-active-class

### `<router-link>` のプロパティ `exact`
`<router-link>` の「アクティブ」の判定を「パスの完全一致」で判定するか否かを設定するプロパティ。
デフォルト値は `false` 。（＝「先頭一致」で判定する）
https://router.vuejs.org/ja/api/#exact